### PR TITLE
Fixing #11 - App doesn't close after closing window

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function createMainWindow() {
       if (process.platform === 'darwin') {
         app.hide();
       } else {
-        win.hide();
+        app.quit();
       }
     }
   });


### PR DESCRIPTION
MacOS keeps the proccess always executing, while other OSes don't, this must be enough to resolve the problem.