### PR TITLE
 Introducing new menu checkbox to show/hide card short id

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,5 +8,6 @@ module.exports = new Config({
       width: 800,
       height: 600
     }
+    , showCardShortId: false
   }
 });


### PR DESCRIPTION
Introducing a new "View" menu and its checkbox item "Show card short id".
All trello cards have a "short id" in a span element, which is hidden. CSS class is ".card-short-id hide".
Checking/unchecking "Show card short id" will page.insertCSS a new class ".card-short-id.hide" definition "display: inline-flex; padding-right: .3em;" or "display: none;" 
Checkbox state is saved in config.
I never developped with electron, so sorry if page.insertCSS is not the right way and please enhance the code !