### PR TITLE
 Introducing new menu checkbox to show/hide card short id

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,7 @@ let showCardShortId = config.get('showCardShortId');
 function toggleShowCardShortId(page) {
   if (showCardShortId) {
     page.insertCSS('.card-short-id.hide { display: inline-flex; padding-right: .3em; }');
-  }
-  else {
+  } else {
     page.insertCSS('.card-short-id.hide { display:none; }');
   }
 }
@@ -125,7 +124,7 @@ app.on('ready', () => {
       {label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:'},
       {label: 'Select All', accelerator: 'CmdOrCtrl+A', selector: 'selectAll:'}
     ]
-  } , {
+  }, {
     label: 'View',
     submenu: [
         {label: 'Show card short id',

--- a/index.js
+++ b/index.js
@@ -15,10 +15,12 @@ let isQuitting = false;
 let showCardShortId = config.get('showCardShortId');
 
 function toggleShowCardShortId(page) {
-  if (!showCardShortId)
-    page.insertCSS('.card-short-id.hide { display:none; }');
-  else
+  if (showCardShortId) {
     page.insertCSS('.card-short-id.hide { display: inline-flex; padding-right: .3em; }');
+  }
+  else {
+    page.insertCSS('.card-short-id.hide { display:none; }');
+  }
 }
 
 function createMainWindow() {
@@ -130,10 +132,10 @@ app.on('ready', () => {
          type: 'checkbox',
          checked: showCardShortId,
          click: item => {
-             showCardShortId = !showCardShortId;
-             item.checked = showCardShortId;
-             config.set('showCardShortId', showCardShortId);
-             toggleShowCardShortId(page);
+           showCardShortId = !showCardShortId;
+           item.checked = showCardShortId;
+           config.set('showCardShortId', showCardShortId);
+           toggleShowCardShortId(page);
          }
         }
     ]

--- a/index.js
+++ b/index.js
@@ -12,14 +12,24 @@ require('electron-context-menu')();
 
 let mainWindow;
 let isQuitting = false;
+let showCardShortId = config.get('showCardShortId');
+
+function toggleShowCardShortId(page) {
+  if (!showCardShortId)
+    page.insertCSS('.card-short-id.hide { display:none; }');
+  else
+    page.insertCSS('.card-short-id.hide { display: inline-flex; padding-right: .3em; }');
+}
 
 function createMainWindow() {
   const lastWindowState = config.get('lastWindowState');
+  const lastShowCardShortId = config.get('showCardShortId');
   const win = new electron.BrowserWindow({
     title: app.getName(),
     show: false,
     x: lastWindowState.x,
     y: lastWindowState.y,
+    showCardShortId: lastShowCardShortId,
     width: lastWindowState.width,
     height: lastWindowState.height,
     icon: process.platform === 'linux' && path.join(__dirname, 'static', 'Icon.png'),
@@ -45,6 +55,7 @@ function createMainWindow() {
       if (!mainWindow.isFullScreen()) {
         config.set('lastWindowState', mainWindow.getBounds());
       }
+      config.set('showCardShortId', mainWindow.showCardShortId);
     } else {
       e.preventDefault();
 
@@ -65,6 +76,7 @@ app.on('ready', () => {
 
   page.on('dom-ready', () => {
     page.insertCSS(fs.readFileSync(path.join(__dirname, 'browser.css'), 'utf8'));
+    toggleShowCardShortId(page);
     mainWindow.show();
   });
 
@@ -111,6 +123,20 @@ app.on('ready', () => {
       {label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:'},
       {label: 'Select All', accelerator: 'CmdOrCtrl+A', selector: 'selectAll:'}
     ]
+  } , {
+    label: 'View',
+    submenu: [
+        {label: 'Show card short id',
+         type: 'checkbox',
+         checked: showCardShortId,
+         click: item => {
+             showCardShortId = !showCardShortId;
+             item.checked = showCardShortId;
+             config.set('showCardShortId', showCardShortId);
+             toggleShowCardShortId(page);
+         }
+        }
+    ]
   }
   ];
 
@@ -128,3 +154,4 @@ app.on('activate', () => {
 app.on('before-quit', () => {
   isQuitting = true;
 });
+


### PR DESCRIPTION
Introducing a new "View" menu and its checkbox item "Show card short id".
All trello cards have a "short id" in a span element, which is hidden. CSS class is ".card-short-id hide".
Checking/unchecking "Show card short id" will page.insertCSS a new class ".card-short-id.hide" definition "display: inline-flex; padding-right: .3em;" or "display: none;"
Checkbox state is saved in config.
I never developped with electron, so sorry if page.insertCSS is not the right way and please enhance the code