### PR TITLE
Introducing new menu checkbox to show/hide card short

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,5 +8,6 @@ module.exports = new Config({
       width: 800,
       height: 600
     }
+    , showCardShortId: false
   }
 });

--- a/index.js
+++ b/index.js
@@ -15,10 +15,11 @@ let isQuitting = false;
 let showCardShortId = config.get('showCardShortId');
 
 function toggleShowCardShortId(page) {
-  if (!showCardShortId)
-    page.insertCSS('.card-short-id.hide { display:none; }');
-  else
+  if (showCardShortId) {
     page.insertCSS('.card-short-id.hide { display: inline-flex; padding-right: .3em; }');
+  } else {
+    page.insertCSS('.card-short-id.hide { display:none; }');
+  }
 }
 
 function createMainWindow() {
@@ -49,7 +50,7 @@ function createMainWindow() {
   }
 
   win.loadURL('https://trello.com/');
-    
+
   win.on('close', e => {
     if (isQuitting) {
       if (!mainWindow.isFullScreen()) {
@@ -123,23 +124,23 @@ app.on('ready', () => {
       {label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:'},
       {label: 'Select All', accelerator: 'CmdOrCtrl+A', selector: 'selectAll:'}
     ]
-  } , {
+  }, {
     label: 'View',
     submenu: [
         {label: 'Show card short id',
          type: 'checkbox',
          checked: showCardShortId,
          click: item => {
-             showCardShortId = !showCardShortId;
-             item.checked = showCardShortId;
-             config.set('showCardShortId', showCardShortId);
-             toggleShowCardShortId(page);
+           showCardShortId = !showCardShortId;
+           item.checked = showCardShortId;
+           config.set('showCardShortId', showCardShortId);
+           toggleShowCardShortId(page);
          }
         }
     ]
   }
   ];
-    
+
   electron.Menu.setApplicationMenu(electron.Menu.buildFromTemplate(template));
 });
 
@@ -148,7 +149,7 @@ app.on('window-all-closed', () => {
 });
 
 app.on('activate', () => {
-    mainWindow.show();
+  mainWindow.show();
 });
 
 app.on('before-quit', () => {


### PR DESCRIPTION
Introducing a new "View" menu and its checkbox item "Show card short id".
All trello cards have a "short id" in a span element, which is hidden. CSS class is ".card-short-id hide".
Checking/unchecking "Show card short id" will page.insertCSS a new class ".card-short-id.hide" definition "display: inline-flex; padding-right: .3em;" or "display: none;" 
Checkbox state is saved in config.
I never developped with electron, so sorry if page.insertCSS is not the right way and please enhance the code !