### PR TITLE
Fixing the problem with missing libraries on some distributions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Terminal=false
 Type=Application
 Icon=/full/path/to/folder/Trello/resources/app/static/Icon.png
 ```
-## Ubuntu 19.04 Disco Dingo
+#### Ubuntu 19.04 Disco Dingo
 
 To be able to use the client on this distro it's necessary to add two new packages: `libgtkextra-3.0` and `libgconf2-dev`. This can be done just typing `sudo apt install libgtkextra-3.0 libgconf2-dev -y` in the terminal.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Terminal=false
 Type=Application
 Icon=/full/path/to/folder/Trello/resources/app/static/Icon.png
 ```
+## Ubuntu 19.04 Disco Dingo
+
+To be able to use the client on this distro it's necessary to add two new packages: `libgtkextra-3.0` and `libgconf2-dev`. This can be done just typing `sudo apt install libgtkextra-3.0 libgconf2-dev -y` in the terminal.
 
 ### Windows
 


### PR DESCRIPTION
As I mentioned in the commit, I didn't had the time to search about those missing libraries, but is potentially something about the newer versions of GNOME. It may be added not as Ubuntu thing, but as a known problem or something.