### PR TITLE
Upgrade election to 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '4'
+- '11'
 deploy:
   provider: releases
   api_key:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "trello-desktop",
   "productName": "Trello",
   "desktopName": "Trello",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Unofficial Trello desktop app",
   "license": "MIT",
   "repository": "danielchatfield/trello-desktop",
@@ -12,7 +12,7 @@
     "url": "http://www.danielchatfield.com"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=11"
   },
   "electronVersion": "0.34.3",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "electron-dl": "^1.0.0"
   },
   "devDependencies": {
-    "electron-packager": "^8.7.1",
-    "electron": "^1.7.3",
+    "electron-packager": "^14.0.0",
+    "electron": "^6.0.0",
     "xo": "*"
   },
   "xo": {


### PR DESCRIPTION
Tested with Linux.  Not test with Windows and OSX.

Should resolve this issue:
`This version of Chrome is not supported. Please upgrade to a supported version.`