### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "electron-dl": "^1.0.0"
   },
   "devDependencies": {
-    "electron-packager": "^8.7.1",
+    "electron-packager": "^12.1.0",
     "electron": "^1.7.3",
     "xo": "*"
   },


### PR DESCRIPTION
On Ubuntu 20.04, the existing release fails with an error "harfbuzz version too old", which appears to be related to the electron version being too old. I went to rebuild the app myself and found this necessary change for the electron packager to work on Node 10. Other than that, rebuilding with a fresh version of electron fixed the original issue. If you could merge and do a new linux release that would be great.