### PR TITLE
Update electron to 9.0.2 and electron packager to 12.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "electron-dl": "^1.0.0"
   },
   "devDependencies": {
-    "electron-packager": "^8.7.1",
-    "electron": "^1.7.3",
+    "electron": "^9.0.2",
+    "electron-packager": "^12.1.0",
     "xo": "*"
   },
   "xo": {


### PR DESCRIPTION
**These updates were needed for package.json to build on Ubuntu 19.10 with node v12.16.2** 

Initially I updated the packager to get a build for node v12.16.2 (see [Fail to run on NodeJS 10. It says "Node 4.0 or above" #863](https://github.com/electron/electron-packager/issues/863))

Afterwards updating to the latest electron to remove a "incompatible with this version of Chrome" alert when running the app.


```
# my machine was missing some of the dependencies
% sudo apt-get install libgconf-2-4

# get the latest electron
% npm install --save-dev electron@latest
% npm run build:linux

# follow install steps
% gtk-launch trello.desktop
```

